### PR TITLE
chore: update pinmame to v3.7.0-222-8133307

### DIFF
--- a/external.sh
+++ b/external.sh
@@ -7,11 +7,10 @@ elif [[ $OSTYPE == 'linux-gnu'* ]]; then
   sudo apt-get install -y libsdl2-dev libsdl2-gfx-dev libsdl2-ttf-dev
 fi
 rm -rf pinmame
-# Pinned: later libpinmame.h revisions include the C++ stdlib headers (<cstdint>
-# etc.) in C++ mode, which leak libc++ templates into the bindgen output, and
-# changed the callback userData from `const void*` to `void* const`. This tag
-# matches the API the Rust source is written against.
-PINMAME_TAG=v3.7.0-46-2b48173
+# Pinned for reproducible builds. The bindgen allowlist in build.rs keeps the
+# C++ stdlib headers that newer revisions include (<cstdint> etc.) from leaking
+# libc++ templates into the generated bindings.
+PINMAME_TAG=v3.7.0-222-8133307
 git clone --depth 1 --branch "$PINMAME_TAG" https://github.com/vpinball/pinmame.git pinmame
 rm -rf pinmame/.git
 cd pinmame

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ mod libpinmame {
 pub mod pinmame;
 mod switches;
 
-extern "C" fn pinmame_on_state_updated_callback(state: i32, _p_user_data: *const c_void) {
+extern "C" fn pinmame_on_state_updated_callback(state: i32, _p_user_data: *mut c_void) {
     info!("OnStateUpdated(): state={}", state);
 
     if state == 0 {
@@ -86,7 +86,7 @@ extern "C" fn pinmame_on_display_available_callback(
     index: i32,
     display_count: i32,
     display_layout: *mut libpinmame::PinmameDisplayLayout,
-    _p_user_data: *const c_void,
+    _p_user_data: *mut c_void,
 ) {
     let layout = unsafe { *display_layout };
 
@@ -111,7 +111,7 @@ unsafe extern "C" fn pinmame_on_display_updated_callback(
     index: i32,
     _display_data: *mut ::std::os::raw::c_void,
     display_layout: *mut PinmameDisplayLayout,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     let display_layout_ref = unsafe { display_layout.as_ref().unwrap() };
     trace!(
@@ -152,7 +152,7 @@ unsafe extern "C" fn pinmame_on_display_updated_callback(
 
 unsafe extern "C" fn pinmame_on_audio_available_callback(
     audio_info: *mut PinmameAudioInfo,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) -> i32 {
     let audio_info = unsafe { audio_info.as_ref().unwrap() };
     let format = match audio_info.format {
@@ -180,7 +180,7 @@ unsafe extern "C" fn pinmame_on_audio_available_callback(
 unsafe extern "C" fn pinmame_on_mech_available_callback(
     mech_no: ::std::os::raw::c_int,
     mech_info: *mut libpinmame::PinmameMechInfo,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     // TODO not sure we need to clone here
     // TODO do we need to free this memory?
@@ -210,7 +210,7 @@ unsafe extern "C" fn pinmame_on_mech_available_callback(
 pub unsafe extern "C" fn pinmame_on_mech_updated_callback(
     mech_no: i32,
     mech_info: *mut PinmameMechInfo,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     let mech_info_ref = unsafe { mech_info.as_ref().unwrap() };
     trace!(
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn pinmame_on_mech_updated_callback(
 extern "C" fn pinmame_on_audio_updated_callback(
     _buffer: *mut ::std::os::raw::c_void,
     samples: i32,
-    _user_data: *const c_void,
+    _user_data: *mut c_void,
 ) -> i32 {
     // trace!("OnAudioUpdated(): samples={}", samples);
 
@@ -251,7 +251,7 @@ extern "C" fn pinmame_on_audio_updated_callback(
 extern "C" fn pinmame_on_sound_command_callback(
     board_no: ::std::os::raw::c_int,
     cmd: ::std::os::raw::c_int,
-    _p_user_data: *const ::std::os::raw::c_void,
+    _p_user_data: *mut ::std::os::raw::c_void,
 ) {
     // TODO
     info!("OnSoundCommand(): boardNo={}, cmd={}", board_no, cmd);
@@ -259,7 +259,7 @@ extern "C" fn pinmame_on_sound_command_callback(
 
 extern "C" fn pinmame_is_key_pressed_callback(
     _keycode: libpinmame::PINMAME_KEYCODE,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) -> i32 {
     //info!("IsKeyPressed: keycode={}", _keycode);
     let tester = unsafe { &*(_user_data as *const Tester) };
@@ -392,7 +392,7 @@ fn main() -> Result<(), String> {
 
     pinmame::set_config(&config);
 
-    pinmame::set_user_data(&tester as *const Tester as *const std::ffi::c_void);
+    pinmame::set_user_data(&tester as *const Tester as *mut std::ffi::c_void);
     pinmame::set_handle_keyboard(false);
     pinmame::set_handle_mechanics(true);
 

--- a/src/pinmame.rs
+++ b/src/pinmame.rs
@@ -99,7 +99,7 @@ pub fn set_config(config: &PinmameConfig) {
     unsafe { PinmameSetConfig(config) }
 }
 
-pub fn set_user_data(user_data: *const std::ffi::c_void) {
+pub fn set_user_data(user_data: *mut std::ffi::c_void) {
     unsafe { PinmameSetUserData(user_data) }
 }
 
@@ -243,7 +243,7 @@ struct GameUserData {
     game: Option<Game>,
 }
 
-extern "C" fn game_callback(game: *mut PinmameGame, mut _p_user_data: *const c_void) {
+extern "C" fn game_callback(game: *mut PinmameGame, mut _p_user_data: *mut c_void) {
     unsafe {
         let game = &mut *game;
         let p_user_data = &mut *(_p_user_data as *mut GameUserData);
@@ -255,7 +255,7 @@ struct GamesUserData {
     games: Vec<Game>,
 }
 
-extern "C" fn games_callback(game: *mut PinmameGame, mut _p_user_data: *const c_void) {
+extern "C" fn games_callback(game: *mut PinmameGame, mut _p_user_data: *mut c_void) {
     unsafe {
         let game = &mut *game;
         let p_user_data = &mut *(_p_user_data as *mut GamesUserData);
@@ -266,7 +266,7 @@ extern "C" fn games_callback(game: *mut PinmameGame, mut _p_user_data: *const c_
 //TODO make private
 pub extern "C" fn pinmame_on_solenoid_updated_callback(
     solenoid_state: *mut PinmameSolenoidState,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     unsafe {
         trace!(
@@ -281,7 +281,7 @@ pub extern "C" fn pinmame_on_solenoid_updated_callback(
 pub unsafe extern "C" fn pinmame_on_console_data_updated_callback(
     _data: *mut ::std::os::raw::c_void,
     size: i32,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     info!("OnConsoleDataUpdated: size={}", size);
 }
@@ -297,7 +297,7 @@ pub unsafe extern "C" fn pinmame_on_log_message_callback(
     log_level: u32,
     format: *const ::std::os::raw::c_char,
     args: VaListType,
-    _user_data: *const ::std::os::raw::c_void,
+    _user_data: *mut ::std::os::raw::c_void,
 ) {
     let str = unsafe { vsprintf::vsprintf(format, args).unwrap() };
     on_log_message(log_level, str);


### PR DESCRIPTION
Bump the pinned pinmame to the latest tag and adapt to its API change: the callback/userData parameter went from 'const void*' to 'void* const', so bindgen now emits *mut c_void where it previously emitted *const c_void. Update the callback signatures, set_user_data, and the userData cast in main accordingly.

The bindgen allowlist added previously keeps the C++ stdlib headers this revision includes from leaking libc++ template internals into the bindings. The DMDSEG -> VIDEO_ROT90 display-type enum rename does not affect this crate (it only uses DMD).